### PR TITLE
Modernize codebase and fix issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ tests/Screenshots
 
 docs/*.blade.php
 docs/**/*.blade.php
-.phpunit.cache/test-results
+.phpunit.cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Solo Dumps is a Laravel package that intercepts `dump()` calls and redirects them to a dedicated terminal window via a TCP server. This keeps browser/API responses clean while centralizing debug output.
+
+## Commands
+
+```bash
+# Run all tests
+./vendor/bin/phpunit
+
+# Run specific test suite
+./vendor/bin/phpunit --testsuite=unit
+./vendor/bin/phpunit --testsuite=integration
+
+# Run single test
+./vendor/bin/phpunit --filter testMethodName
+
+# Start the dump server (for manual testing)
+php vendor/bin/testbench solo:dumps
+```
+
+## Architecture
+
+### Data Flow
+
+```
+dump() call in app
+    ↓
+CustomDumper (VarDumper handler)
+    ↓ resolves source file/line
+    ↓ clones var with dumpSource context
+ServerDumper → TCP socket (127.0.0.1:9984)
+    ↓
+DumpServer in `solo:dumps` command
+    ↓ extracts dumpSource from context
+CliDumper → terminal output with source info
+```
+
+### Key Components
+
+- **CustomDumper** (`src/Support/CustomDumper.php`): Registers a custom VarDumper handler that:
+  - Resolves dump source (file:line) before sending
+  - Checks if dump server port is open
+  - Falls back to original handler if server unavailable
+
+- **Dumps Command** (`src/Console/Commands/Dumps.php`): Runs the TCP server that receives and displays dumps with source information
+
+### Fallback Behavior
+
+When the dump server isn't running, CustomDumper falls back to the original dump handler. The `portOpen()` check prevents drops on first dump (ServerDumper's built-in fallback only kicks in after first failure).
+
+## Configuration
+
+Host configured via `config/solo.php`:
+```php
+'dump_server_host' => 'tcp://127.0.0.1:9984'
+```
+
+## Testing Notes
+
+Integration tests spawn real processes to test the server/client interaction. Tests use Orchestra Testbench with process helpers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ php vendor/bin/testbench solo:dumps
 
 ### Data Flow
 
-```
+```text
 dump() call in app
     ↓
 CustomDumper (VarDumper handler)

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
         "php": "^8.1",
         "illuminate/support": "^10|^11|^12",
@@ -48,8 +49,6 @@
         "serve": [
             "Composer\\Config::disableProcessTimeout",
             "@php vendor/bin/testbench serve --ansi"
-        ],
-        "dev": [
         ]
     }
 }

--- a/src/Console/Commands/DumpTestOnly.php
+++ b/src/Console/Commands/DumpTestOnly.php
@@ -23,7 +23,7 @@ class DumpTestOnly extends Command
         $this->setHidden();
     }
 
-    public function handle()
+    public function handle(): void
     {
         if ($this->option('uuid')) {
             dump($this->option('uuid'));

--- a/src/Console/Commands/Dumps.php
+++ b/src/Console/Commands/Dumps.php
@@ -22,7 +22,7 @@ class Dumps extends Command
 
     protected $description = 'Collect dumps from your Laravel application.';
 
-    public function handle()
+    public function handle(): void
     {
         $dumper = new CliDumper(
             output: $this->getOutput()->getOutput(),

--- a/src/Providers/DumpServiceProvider.php
+++ b/src/Providers/DumpServiceProvider.php
@@ -11,24 +11,22 @@ namespace SoloTerm\Dumps\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use SoloTerm\Dumps\Console\Commands\Dumps;
-use SoloTerm\Dumps\Console\Commands\DumpTestOnly;
 use SoloTerm\Dumps\Support\CustomDumper;
 
 class DumpServiceProvider extends ServiceProvider
 {
-    public function register()
+    public function register(): void
     {
         //
     }
 
-    public function boot()
+    public function boot(): void
     {
         CustomDumper::register($this->app->basePath(), $this->app['config']->get('view.compiled'));
 
         if ($this->app->runningInConsole()) {
             $this->commands([
                 Dumps::class,
-                DumpTestOnly::class,
             ]);
         }
     }

--- a/src/Support/CustomDumper.php
+++ b/src/Support/CustomDumper.php
@@ -10,7 +10,6 @@
 namespace SoloTerm\Dumps\Support;
 
 use Illuminate\Foundation\Console\CliDumper;
-use Illuminate\Foundation\Console\CliDumper as LaravelCliDumper;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\VarDumper\Caster\ReflectionCaster;
 use Symfony\Component\VarDumper\Cloner\Data;
@@ -22,7 +21,7 @@ use Throwable;
 
 class CustomDumper
 {
-    public static function register($basePath, $compiledViewPath): static
+    public static function register(string $basePath, ?string $compiledViewPath): static
     {
         return new static($basePath, $compiledViewPath);
     }
@@ -32,7 +31,7 @@ class CustomDumper
         return config()->get('solo.dump_server_host', 'tcp://127.0.0.1:9984');
     }
 
-    public function __construct(public string $basePath, public string $compiledViewPath)
+    public function __construct(public string $basePath, public ?string $compiledViewPath)
     {
         $cloner = new VarCloner;
         $cloner->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
@@ -89,7 +88,7 @@ class CustomDumper
     {
         $output = new StreamOutput(fopen('php://memory', 'w'));
 
-        return new LaravelCliDumper($output, $this->basePath, $this->compiledViewPath);
+        return new CliDumper($output, $this->basePath, $this->compiledViewPath);
     }
 
     protected function makeFallbackDumper(): DataDumperInterface

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -1,5 +1,6 @@
 providers:
   - SoloTerm\Dumps\Providers\DumpServiceProvider
+  - SoloTerm\Dumps\Tests\Support\DumpTestServiceProvider
   - App\Providers\AppServiceProvider
 
 migrations: false

--- a/tests/Integration/BasicTest.php
+++ b/tests/Integration/BasicTest.php
@@ -54,8 +54,6 @@ class BasicTest extends Base
         $loop = Process::start('php vendor/bin/testbench solo:dump-test-only --loop');
         sleep(2);
 
-        ob_get_clean();
-
         echo json_encode($server->running());
         echo PHP_EOL;
         echo $server->output();

--- a/tests/Support/DumpTestServiceProvider.php
+++ b/tests/Support/DumpTestServiceProvider.php
@@ -10,11 +10,16 @@
 namespace SoloTerm\Dumps\Tests\Support;
 
 use Illuminate\Support\ServiceProvider;
+use SoloTerm\Dumps\Console\Commands\DumpTestOnly;
 
 class DumpTestServiceProvider extends ServiceProvider
 {
-    public function boot()
+    public function boot(): void
     {
-        //
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                DumpTestOnly::class,
+            ]);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Fix risky test by removing `ob_get_clean()` call in BasicTest
- Make `compiledViewPath` nullable to handle edge cases where config may not be set
- Remove redundant `CliDumper` import alias in CustomDumper
- Add `void` return types to service provider `register()` and `boot()` methods
- Add `void` return types to command `handle()` methods
- Add parameter types to `CustomDumper::register()`
- Move `DumpTestOnly` command to test-only service provider (keeps it out of production)
- Add `prefer-stable: true` to composer.json (recommended with `minimum-stability: dev`)
- Fix `.phpunit.cache` gitignore pattern to ignore entire directory
- Remove empty `dev` script from composer.json
- Add CLAUDE.md documentation for Claude Code

## Test plan

- [x] All PHPUnit tests pass
- [x] No risky test warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added developer guidance documentation for repository interactions.

* **Refactor**
  * Improved type safety with explicit return type declarations across components.
  * Enhanced type annotations in method signatures and constructors.

* **Bug Fixes**
  * Fixed output buffer handling in integration tests.

* **Chores**
  * Updated dependency stability preference in package configuration.
  * Removed unused development script entry.
  * Updated test environment configuration.
  * Refined gitignore patterns for cache files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->